### PR TITLE
⬆️ Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,8 @@ endif()
 set(SRC_DIR "${PROJECT_SOURCE_DIR}/src")
 
 include(GNUInstallDirs)
-find_package(Qt5 COMPONENTS Core Quick Qml Gui CONFIG REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core CONFIG REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Quick Qml Gui CONFIG REQUIRED)
 
 set(quickflux_PRIVATE_SOURCES
   ${SRC_DIR}/priv/qfhook.cpp
@@ -99,9 +100,9 @@ add_library(QuickFlux::quickflux ALIAS quickflux)
 
 target_link_libraries(quickflux
   PUBLIC
-  Qt5::Qml
-  Qt5::Quick
-  Qt5::Core
+  Qt${QT_VERSION_MAJOR}::Qml
+  Qt${QT_VERSION_MAJOR}::Quick
+  Qt${QT_VERSION_MAJOR}::Core
   )
 
 target_include_directories(quickflux

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ include(vendor/vendor.pri)
  3) Add import statement in your QML file
 
 ```
-import QuickFlux 1.0
+import QuickFlux 1.1
 ```
 
 Installation Instruction (without qpm)
@@ -84,7 +84,7 @@ Installation Instruction (without qpm)
  3) Add import statement in your QML file
 
 ```
-import QuickFlux 1.0
+import QuickFlux 1.1
 ```
 
 Installation Instruction (with CMake)

--- a/examples/middleware/actions/ActionTypes.qml
+++ b/examples/middleware/actions/ActionTypes.qml
@@ -1,6 +1,6 @@
 pragma Singleton
-import QtQuick 2.0
-import QuickFlux 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
 
 KeyTable {
     id: actionTypes;

--- a/examples/middleware/actions/AppActions.qml
+++ b/examples/middleware/actions/AppActions.qml
@@ -1,6 +1,6 @@
 pragma Singleton
-import QtQuick 2.0
-import QuickFlux 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
 import "./"
 
 ActionCreator {

--- a/examples/middleware/components/ImagePreview.qml
+++ b/examples/middleware/components/ImagePreview.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.0
-import QtQuick.Layouts 1.1
-import QtQuick.Controls 1.2
-import QuickFlux 1.0
+import QtQuick 6.4
+import QtQuick.Layouts 6.4
+import QtQuick.Controls 6.4
+import QuickFlux 1.1
 import "../actions"
 
 Rectangle {

--- a/examples/middleware/main.qml
+++ b/examples/middleware/main.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.3
-import QtQuick.Window 2.2
-import QtQuick.Controls 1.3
+import QtQuick 6.4
+import QtQuick.Window 6.4
+import QtQuick.Controls 6.4
 import QuickFlux 1.1
 import "./views"
 import "./actions"

--- a/examples/middleware/middleware.pro
+++ b/examples/middleware/middleware.pro
@@ -1,7 +1,7 @@
 TEMPLATE = app
 
 QT += qml quick
-CONFIG += c++11
+CONFIG += c++17
 
 SOURCES += main.cpp
 

--- a/examples/middleware/middlewares/ImagePickerMiddleware.qml
+++ b/examples/middleware/middlewares/ImagePickerMiddleware.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.0
-import QtQuick.Dialogs 1.0
+import QtQuick 6.4
+import QtQuick.Dialogs 6.4
 import QuickFlux 1.1
 import "../actions"
 import "../components"

--- a/examples/middleware/middlewares/NavigationMiddleware.qml
+++ b/examples/middleware/middlewares/NavigationMiddleware.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 6.4
 import QuickFlux 1.1
 
 Middleware {

--- a/examples/middleware/stores/MainStore.qml
+++ b/examples/middleware/stores/MainStore.qml
@@ -1,5 +1,5 @@
 pragma Singleton
-import QtQuick 2.0
+import QtQuick 6.4
 
 RootStore {
 }

--- a/examples/middleware/stores/RootStore.qml
+++ b/examples/middleware/stores/RootStore.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 6.4
 import QuickFlux 1.1
 import "../actions"
 

--- a/examples/middleware/views/ImageViewer.qml
+++ b/examples/middleware/views/ImageViewer.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
-import QtQuick.Layouts 1.1
-import QtQuick.Controls 1.3
+import QtQuick 6.4
+import QtQuick.Layouts 6.4
+import QtQuick.Controls 6.4
 import "../stores"
 import "../actions"
 

--- a/examples/middleware/views/StackView.qml
+++ b/examples/middleware/views/StackView.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.3
-import QuickFlux 1.0
+import QtQuick 6.4
+import QtQuick.Controls 6.4
+import QuickFlux 1.1
 import "../actions"
 
 StackView {

--- a/examples/photoalbum/actions/ActionTypes.qml
+++ b/examples/photoalbum/actions/ActionTypes.qml
@@ -1,6 +1,6 @@
 pragma Singleton
-import QtQuick 2.0
-import QuickFlux 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
 
 KeyTable {
     id: actionTypes;

--- a/examples/photoalbum/actions/AppActions.qml
+++ b/examples/photoalbum/actions/AppActions.qml
@@ -1,6 +1,6 @@
 pragma Singleton
-import QtQuick 2.0
-import QuickFlux 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
 import "./"
 
 ActionCreator {

--- a/examples/photoalbum/main.qml
+++ b/examples/photoalbum/main.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.3
-import QtQuick.Window 2.2
-import QtQuick.Controls 1.3
-import QuickFlux 1.0
+import QtQuick 6.4
+import QtQuick.Window 6.4
+import QtQuick.Controls 6.4
+import QuickFlux 1.1
 import "./views"
 import "./scripts"
 import "./actions"

--- a/examples/photoalbum/scripts/ImagePickerScript.qml
+++ b/examples/photoalbum/scripts/ImagePickerScript.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
-import QuickFlux 1.0
-import QtQuick.Dialogs 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
+import QtQuick.Dialogs 6.4
 import "../actions"
 import "../views"
 import "../stores"

--- a/examples/photoalbum/stores/PhotoStore.qml
+++ b/examples/photoalbum/stores/PhotoStore.qml
@@ -1,5 +1,5 @@
 pragma Singleton
-import QtQuick 2.0
+import QtQuick 6.4
 import "../actions"
 
 Item {

--- a/examples/photoalbum/views/ImagePreview.qml
+++ b/examples/photoalbum/views/ImagePreview.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.0
-import QtQuick.Layouts 1.1
-import QtQuick.Controls 1.2
-import QuickFlux 1.0
+import QtQuick 6.4
+import QtQuick.Layouts 6.4
+import QtQuick.Controls 6.4
+import QuickFlux 1.1
 import "../actions"
 
 Rectangle {

--- a/examples/photoalbum/views/ImageViewer.qml
+++ b/examples/photoalbum/views/ImageViewer.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
-import QtQuick.Layouts 1.1
-import QtQuick.Controls 1.3
+import QtQuick 6.4
+import QtQuick.Layouts 6.4
+import QtQuick.Controls 6.4
 import "../stores"
 import "../actions"
 

--- a/examples/photoalbum/views/StackView.qml
+++ b/examples/photoalbum/views/StackView.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.3
-import QuickFlux 1.0
+import QtQuick 6.4
+import QtQuick.Controls 6.4
+import QuickFlux 1.1
 import "../actions"
 
 Item {

--- a/examples/todo/MainWindow.qml
+++ b/examples/todo/MainWindow.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.3
-import QtQuick.Window 2.2
-import QtQuick.Layouts 1.0
+import QtQuick 6.4
+import QtQuick.Window 6.4
+import QtQuick.Layouts 6.4
 import QuickFlux 1.1
 import "./views"
 import "./middlewares"

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -44,7 +44,7 @@ Example:
 ```
 pragma Singleton
 import QtQuick 2.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 KeyTable {
     // KeyTable is an object with properties equal to its key name

--- a/examples/todo/actions/ActionTypes.qml
+++ b/examples/todo/actions/ActionTypes.qml
@@ -1,6 +1,6 @@
 pragma Singleton
-import QtQuick 2.0
-import QuickFlux 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
 
 KeyTable {
     // KeyTable is an object with properties equal to its key name

--- a/examples/todo/actions/AppActions.qml
+++ b/examples/todo/actions/AppActions.qml
@@ -1,5 +1,5 @@
 pragma Singleton
-import QtQuick 2.0
+import QtQuick 6.4
 import QuickFlux 1.1
 import "./"
 

--- a/examples/todo/main.qml
+++ b/examples/todo/main.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.3
-import QtQuick.Window 2.2
-import QtQuick.Layouts 1.0
+import QtQuick 6.4
+import QtQuick.Window 6.4
+import QtQuick.Layouts 6.4
 import QuickFlux 1.1
 import "./views"
 import "./middlewares"

--- a/examples/todo/middlewares/DialogMiddleware.qml
+++ b/examples/todo/middlewares/DialogMiddleware.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
+import QtQuick 6.4
 import QuickFlux 1.1
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs 6.4
 import "../actions"
 import "../stores"
 
@@ -12,7 +12,7 @@ Middleware {
         id: dialog
         title: "Confirmation"
         text: "Are you sure want to show completed tasks?"
-        standardButtons: StandardButton.Ok | StandardButton.Cancel
+        buttons: MessageDialog.Ok | MessageDialog.Cancel
 
         onAccepted: {
             next(ActionTypes.setShowCompletedTasks, {value: true});

--- a/examples/todo/middlewares/SystemMiddleware.qml
+++ b/examples/todo/middlewares/SystemMiddleware.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
+import QtQuick 6.4
 import QuickFlux 1.1
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs 6.4
 import "../actions"
 import "../stores"
 

--- a/examples/todo/stores/MainStore.qml
+++ b/examples/todo/stores/MainStore.qml
@@ -1,5 +1,5 @@
 pragma Singleton
-import QtQuick 2.0
+import QtQuick 6.4
 import QuickFlux 1.1
 
 RootStore {

--- a/examples/todo/stores/RootStore.qml
+++ b/examples/todo/stores/RootStore.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 6.4
 import QuickFlux 1.1
 
 Store {

--- a/examples/todo/stores/TodoStore.qml
+++ b/examples/todo/stores/TodoStore.qml
@@ -3,7 +3,7 @@
   A centralized data store of Todo list.
 
  */
-import QtQuick 2.0
+import QtQuick 6.4
 import QuickFlux 1.1
 import "../actions"
 

--- a/examples/todo/stores/UserPrefsStore.qml
+++ b/examples/todo/stores/UserPrefsStore.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 6.4
 import QuickFlux 1.1
 import "../actions"
 

--- a/examples/todo/views/Footer.qml
+++ b/examples/todo/views/Footer.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Layouts 1.0
+import QtQuick 6.4
+import QtQuick.Controls 6.4
+import QtQuick.Layouts 6.4
 import "../actions"
 
 Item {

--- a/examples/todo/views/Header.qml
+++ b/examples/todo/views/Header.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.0
+import QtQuick 6.4
+import QtQuick.Controls 6.4
 import "../actions"
 import "../stores"
 

--- a/examples/todo/views/TodoItem.qml
+++ b/examples/todo/views/TodoItem.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.0
-import QtQuick.Layouts 1.0
+import QtQuick 6.4
+import QtQuick.Controls 6.4
+import QtQuick.Layouts 6.4
 import "../actions"
 
 Rectangle {

--- a/examples/todo/views/TodoList.qml
+++ b/examples/todo/views/TodoList.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.0
-import QuickFlux 1.0
-import QtQuick.Controls 1.0
-import QtQuick.Layouts 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
+import QtQuick.Controls 6.4
+import QtQuick.Layouts 6.4
 import "../stores"
 
 ScrollView {

--- a/examples/todo/views/TodoVisualModel.qml
+++ b/examples/todo/views/TodoVisualModel.qml
@@ -1,16 +1,16 @@
-import QtQuick 2.0
-import QuickFlux 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
 import "../stores"
 import "../actions"
 
-VisualDataModel {
+DelegateModel {
 
     model: MainStore.todo.model
 
     filterOnGroup: MainStore.userPrefs.showCompletedTasks ? "" : "nonCompleted"
 
     groups: [
-        VisualDataGroup {
+        DelegateModelGroup {
             name: "nonCompleted"
             includeByDefault: true
         }

--- a/src/priv/qfsignalproxy.cpp
+++ b/src/priv/qfsignalproxy.cpp
@@ -49,7 +49,11 @@ int QFSignalProxy::qt_metacall(QMetaObject::Call _c, int _id, void **_a)
                 if (type == QMetaType::QVariant) {
                     v = *reinterpret_cast<QVariant *>(_a[i + 1]);
                 } else {
+		#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
                     v = QVariant(type, _a[i + 1]);
+		#else
+                    v = QVariant(QMetaType{type}, _a[i + 1]);
+		#endif
                 }
 
                 message[parameterNames.at(i)] = v;

--- a/src/qfactioncreator.cpp
+++ b/src/qfactioncreator.cpp
@@ -15,7 +15,7 @@ For example, you may declare an ActionCreator based component as:
 
 \code
 import QtQuick 2.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 pragma singleton
 
 ActionCreator {
@@ -27,7 +27,7 @@ It is equivalent to:
 
 \code
 import QtQuick 2.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 pragma singleton
 
 Item {
@@ -50,7 +50,7 @@ QString QFActionCreator::genKeyTable()
 
     imports << "pragma Singleton"
             << "import QtQuick 2.0"
-            << "import QuickFlux 1.0\n";
+            << "import QuickFlux 1.1\n";
 
     header << "KeyTable {\n";
 

--- a/src/qfappdispatcher.cpp
+++ b/src/qfappdispatcher.cpp
@@ -50,7 +50,7 @@ QFAppDispatcher *QFAppDispatcher::instance(QQmlEngine *engine)
 
 QObject *QFAppDispatcher::singletonObject(QQmlEngine *engine, QString package, int versionMajor, int versionMinor, QString typeName)
 {
-    QString pattern  = "import QtQuick 2.0\nimport %1 %2.%3;QtObject { property var object : %4 }";
+    QString pattern  = "import QtQuick 6.3\nimport %1 %2.%3;QtObject { property var object : %4 }";
 
     QString qml = pattern.arg(package).arg(versionMajor).arg(versionMinor).arg(typeName);
 

--- a/src/qffilter.cpp
+++ b/src/qffilter.cpp
@@ -21,7 +21,7 @@ Example:
 
 pragma Singleton
 import QtQuick 2.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 import "../actions"
 
 AppListener {

--- a/src/qfhydrate.cpp
+++ b/src/qfhydrate.cpp
@@ -125,7 +125,7 @@ void QFHydrate::rehydrate(QObject *dest, const QVariantMap &source)
         QVariant value = source[iter.key()];
 
         if (orig.canConvert<QObject*>()) {
-            if (value.type() != QVariant::Map) {
+            if (value.userType() != QMetaType::QVariantMap) {
                 qWarning() << QString("Hydrate.rehydrate: expect a QVariantMap property but it is not: %1");
             } else {
                 rehydrate(orig.value<QObject*>(), value.toMap());

--- a/src/qfkeytable.cpp
+++ b/src/qfkeytable.cpp
@@ -31,12 +31,12 @@ KeyTable {
 
 static QMap<int,QString> createTypes() {
     QMap<int,QString> types;
-    types[QVariant::String] = "QString";
-    types[QVariant::Int] = "int";
-    types[QVariant::Double] = "qreal";
-    types[QVariant::Bool] = "bool";
-    types[QVariant::PointF] = "QPointF";
-    types[QVariant::RectF] = "QRectF";
+    types[QMetaType::QString] = "QString";
+    types[QMetaType::Int] = "int";
+    types[QMetaType::Double] = "qreal";
+    types[QMetaType::Bool] = "bool";
+    types[QMetaType::QPointF] = "QPointF";
+    types[QMetaType::QRectF] = "QRectF";
 
     return types;
 }
@@ -74,13 +74,13 @@ QString QFKeyTable::genHeaderFile(const QString& className)
             continue;
         }
 
-        if (types.contains(p.type())) {
-            clazz << QString("    static %2 %1;\n").arg(name).arg(types[p.type()]);
+        if (types.contains(p.userType())) {
+            clazz << QString("    static %2 %1;\n").arg(name).arg(types[p.userType()]);
 
-            if (p.type() == QVariant::PointF && !includedPointHeader) {
+            if (p.userType() == QMetaType::QPointF && !includedPointHeader) {
                 includedPointHeader = true;
                 header << "#include <QPointF>";
-            } else if (p.type() == QVariant::RectF && !includedRectHeader) {
+            } else if (p.userType() == QMetaType::QRectF && !includedRectHeader) {
                 includedRectHeader = true;
                 header << "#include <QRectF>";
             }
@@ -114,17 +114,17 @@ QString QFKeyTable::genSourceFile(const QString &className, const QString &heade
             continue;
         }
 
-        if (types.contains(p.type())) {
+        if (types.contains(p.userType())) {
             QVariant v = property(p.name());
 
-            if (p.type() == QVariant::String) {
+            if (p.userType() == QMetaType::QString) {
                 source << QString("%4 %1::%2 = \"%3\";\n")
                           .arg(className)
                           .arg(p.name())
                           .arg(v.toString())
-                          .arg(types[p.type()]);
+                          .arg(types[p.userType()]);
 
-            } else if (p.type() == QVariant::PointF) {
+            } else if (p.userType() == QMetaType::QPointF) {
                 QPointF pt = v.toPointF();
 
                 source << QString("QPointF %1::%2 = QPointF(%3,%4);\n")
@@ -133,7 +133,7 @@ QString QFKeyTable::genSourceFile(const QString &className, const QString &heade
                           .arg(pt.x())
                           .arg(pt.y());
 
-            } else if (p.type() == QVariant::RectF) {
+            } else if (p.userType() == QMetaType::QRectF) {
 
                 QRectF rect = v.toRectF();
 
@@ -151,7 +151,7 @@ QString QFKeyTable::genSourceFile(const QString &className, const QString &heade
                           .arg(className)
                           .arg(p.name())
                           .arg(v.toString())
-                          .arg(types[p.type()]);
+                          .arg(types[p.userType()]);
             }
         }
     }
@@ -172,13 +172,13 @@ void QFKeyTable::componentComplete()
     for (int i = 0 ; i < count ; i++) {
         const QMetaProperty p = meta->property(i);
         QString name(p.name());
-        if (p.type() != QVariant::String ||
+        if (p.userType() != QMetaType::QString ||
             name == "objectName") {
             continue;
         }
 
         QVariant v = property(p.name());
-        if (!v.isNull()) {
+        if (!v.toString().isEmpty()) {
             continue;
         }
 

--- a/src/qfstore.cpp
+++ b/src/qfstore.cpp
@@ -117,15 +117,15 @@ Store {
 The default value is false
  */
 
-
-QFStore::QFStore(QObject *parent) : QObject(parent) , m_filterFunctionEnabled(false)
+QFStore::QFStore(QObject* parent)
+    : QObject(parent)
+    , m_filterFunctionEnabled(false)
 {
-
 }
 
 QQmlListProperty<QObject> QFStore::children()
 {
-    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), m_children);
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), &m_children);
 }
 
 void QFStore::dispatch(QString type, QJSValue message)
@@ -133,38 +133,45 @@ void QFStore::dispatch(QString type, QJSValue message)
     QQmlEngine* engine = qmlEngine(this);
     QF_PRECHECK_DISPATCH(engine, type, message);
 
-    foreach(QObject* child , m_children) {
+    foreach(QObject* child, m_children)
+    {
         QFStore* store = qobject_cast<QFStore*>(child);
-        if (!store) {
+        if(!store)
+        {
             continue;
         }
         store->dispatch(type, message);
     }
 
-    foreach(QObject* child , m_redispatchTargets) {
+    foreach(QObject* child, m_redispatchTargets)
+    {
         QFStore* store = qobject_cast<QFStore*>(child);
 
-        if (!store) {
+        if(!store)
+        {
             continue;
         }
         store->dispatch(type, message);
     }
 
-    if (m_filterFunctionEnabled) {
-        const QMetaObject *meta = metaObject();
+    if(m_filterFunctionEnabled)
+    {
+        const QMetaObject* meta = metaObject();
         QByteArray signature;
         int index;
 
         signature = QMetaObject::normalizedSignature(QString("%1(QVariant)").arg(type).toUtf8().constData());
-        if ( (index = meta->indexOfMethod(signature.constData())) >= 0 ) {
+        if((index = meta->indexOfMethod(signature.constData())) >= 0)
+        {
             QMetaMethod method = meta->method(index);
             QVariant value = QVariant::fromValue<QJSValue>(message);
 
-            method.invoke(this,Qt::DirectConnection, Q_ARG(QVariant, value));
+            method.invoke(this, Qt::DirectConnection, Q_ARG(QVariant, value));
         }
 
         signature = QMetaObject::normalizedSignature(QString("%1()").arg(type).toUtf8().constData());
-        if ( (index = meta->indexOfMethod(signature.constData())) >= 0 ) {
+        if((index = meta->indexOfMethod(signature.constData())) >= 0)
+        {
             QMetaMethod method = meta->method(index);
 
             method.invoke(this);
@@ -174,53 +181,55 @@ void QFStore::dispatch(QString type, QJSValue message)
     emit dispatched(type, message);
 }
 
-void QFStore::bind(QObject *source)
+void QFStore::bind(QObject* source)
 {
     setBindSource(source);
 }
 
 void QFStore::setup()
 {
-    QFActionCreator *creator = 0;
+    QFActionCreator* creator = 0;
     QFDispatcher* dispatcher = 0;
 
     creator = qobject_cast<QFActionCreator*>(m_bindSource.data());
 
-    if (creator) {
+    if(creator)
+    {
         dispatcher = creator->dispatcher();
-    } else {
+    }
+    else
+    {
         dispatcher = qobject_cast<QFDispatcher*>(m_bindSource.data());
     }
 
-    if (m_actionCreator.data() == creator &&
-        m_dispatcher.data() == dispatcher) {
+    if(m_actionCreator.data() == creator && m_dispatcher.data() == dispatcher)
+    {
         // Nothing changed.
         return;
     }
 
-    if (!m_actionCreator.isNull() &&
-        m_actionCreator.data() != creator) {
+    if(!m_actionCreator.isNull() && m_actionCreator.data() != creator)
+    {
         m_actionCreator->disconnect(this);
     }
 
-    if (!m_dispatcher.isNull() &&
-        m_dispatcher.data() != dispatcher) {
+    if(!m_dispatcher.isNull() && m_dispatcher.data() != dispatcher)
+    {
         m_dispatcher->disconnect(this);
     }
 
     m_actionCreator = creator;
     m_dispatcher = dispatcher;
 
-    if (!m_actionCreator.isNull()) {
-        connect(m_actionCreator.data(),SIGNAL(dispatcherChanged()),
-                this,SLOT(setup()));
+    if(!m_actionCreator.isNull())
+    {
+        connect(m_actionCreator.data(), SIGNAL(dispatcherChanged()), this, SLOT(setup()));
     }
 
-    if (!m_dispatcher.isNull()) {
-        connect(dispatcher,SIGNAL(dispatched(QString,QJSValue)),
-                this,SLOT(dispatch(QString,QJSValue)));
+    if(!m_dispatcher.isNull())
+    {
+        connect(dispatcher, SIGNAL(dispatched(QString, QJSValue)), this, SLOT(dispatch(QString, QJSValue)));
     }
-
 }
 
 /*! \qmlproperty array Store::redispatchTargets
@@ -245,9 +254,8 @@ void QFStore::setup()
 
 QQmlListProperty<QObject> QFStore::redispatchTargets()
 {
-    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), m_redispatchTargets);
+    return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), &m_redispatchTargets);
 }
-
 
 /*! \qmlproperty object Store::bindSource
  *
@@ -256,13 +264,12 @@ QQmlListProperty<QObject> QFStore::redispatchTargets()
  * The default value is null, and it listens to AppDispatcher
  */
 
-
-QObject *QFStore::bindSource() const
+QObject* QFStore::bindSource() const
 {
     return m_bindSource.data();
 }
 
-void QFStore::setBindSource(QObject *source)
+void QFStore::setBindSource(QObject* source)
 {
     m_bindSource = source;
     setup();

--- a/templates/quickflux-project-template/App/actions/ActionTypes.qml
+++ b/templates/quickflux-project-template/App/actions/ActionTypes.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 import QtQuick 2.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 KeyTable {
     // Call it when the initialization is finished.

--- a/templates/quickflux-project-template/App/actions/AppActions.qml
+++ b/templates/quickflux-project-template/App/actions/AppActions.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 import QtQuick 2.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 ActionCreator {
 

--- a/templates/quickflux-project-template/App/adapters/StoreAdapter.qml
+++ b/templates/quickflux-project-template/App/adapters/StoreAdapter.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 import "../storeworkers"
 
 Item {

--- a/templates/quickflux-project-template/App/constants/Constants.qml
+++ b/templates/quickflux-project-template/App/constants/Constants.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 import QtQuick 2.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 KeyTable {
 }

--- a/templates/quickflux-project-template/App/storeworkers/MainStoreWorker.qml
+++ b/templates/quickflux-project-template/App/storeworkers/MainStoreWorker.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 import App.actions 1.0
 import App.stores 1.0
 

--- a/tests/quickfluxunittests/QuickFluxTests/ActionTypes.qml
+++ b/tests/quickfluxunittests/QuickFluxTests/ActionTypes.qml
@@ -1,6 +1,6 @@
 pragma Singleton
-import QtQuick 2.0
-import QuickFlux 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
 
 KeyTable {
 

--- a/tests/quickfluxunittests/QuickFluxTests/AppActions.qml
+++ b/tests/quickfluxunittests/QuickFluxTests/AppActions.qml
@@ -1,6 +1,6 @@
 pragma Singleton
-import QtQuick 2.0
-import QuickFlux 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
 
 ActionCreator {
 

--- a/tests/quickfluxunittests/QuickFluxTests/AppActionsKeyTable.qml
+++ b/tests/quickfluxunittests/QuickFluxTests/AppActionsKeyTable.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 import QtQuick 2.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 KeyTable {
 

--- a/tests/quickfluxunittests/QuickFluxTests/DispatcherTests.qml
+++ b/tests/quickfluxunittests/QuickFluxTests/DispatcherTests.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.0
-import QuickFlux 1.0
+import QtQuick 6.4
+import QuickFlux 1.1
 
 Item {
 

--- a/tests/quickfluxunittests/QuickFluxTests/DummyAction.qml
+++ b/tests/quickfluxunittests/QuickFluxTests/DummyAction.qml
@@ -1,5 +1,5 @@
 pragma Singleton
-import QtQuick 2.0
+import QtQuick 6.4
 
 QtObject {
     property int value: 13

--- a/tests/quickfluxunittests/dummy.qml
+++ b/tests/quickfluxunittests/dummy.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 6.4
 
 Item {
 

--- a/tests/quickfluxunittests/qmltests/tst_appdispatcher.qml
+++ b/tests/quickfluxunittests/qmltests/tst_appdispatcher.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
     name : "AppDispatcher"

--- a/tests/quickfluxunittests/qmltests/tst_appdispatcher_dispatch_reentrant.qml
+++ b/tests/quickfluxunittests/qmltests/tst_appdispatcher_dispatch_reentrant.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
     name : "Dispatcher_dispatch_reentrant"

--- a/tests/quickfluxunittests/qmltests/tst_appdispatcher_waitfor.qml
+++ b/tests/quickfluxunittests/qmltests/tst_appdispatcher_waitfor.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
     name : "Dispatcher_waitFor"

--- a/tests/quickfluxunittests/qmltests/tst_applistener.qml
+++ b/tests/quickfluxunittests/qmltests/tst_applistener.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
 

--- a/tests/quickfluxunittests/qmltests/tst_applistener_alwayson.qml
+++ b/tests/quickfluxunittests/qmltests/tst_applistener_alwayson.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
 

--- a/tests/quickfluxunittests/qmltests/tst_applistener_filter.qml
+++ b/tests/quickfluxunittests/qmltests/tst_applistener_filter.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
 

--- a/tests/quickfluxunittests/qmltests/tst_applistener_waitfor.qml
+++ b/tests/quickfluxunittests/qmltests/tst_applistener_waitfor.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
     name : "AppListener_waitFor"

--- a/tests/quickfluxunittests/qmltests/tst_applistenergroup.qml
+++ b/tests/quickfluxunittests/qmltests/tst_applistenergroup.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
     id: testCase

--- a/tests/quickfluxunittests/qmltests/tst_appscript.qml
+++ b/tests/quickfluxunittests/qmltests/tst_appscript.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
     name : "AppScriptTests"

--- a/tests/quickfluxunittests/qmltests/tst_appscriptgroup.qml
+++ b/tests/quickfluxunittests/qmltests/tst_appscriptgroup.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
     name : "AppScriptGroupTests"

--- a/tests/quickfluxunittests/qmltests/tst_filter.qml
+++ b/tests/quickfluxunittests/qmltests/tst_filter.qml
@@ -1,7 +1,7 @@
 // To prove that it could pass QImage via AppDispatcher
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
     name : "FilterTests"

--- a/tests/quickfluxunittests/qmltests/tst_keytable.qml
+++ b/tests/quickfluxunittests/qmltests/tst_keytable.qml
@@ -1,7 +1,7 @@
 // To prove that it could pass QImage via AppDispatcher
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
     name : "KeyTableTests"

--- a/tests/quickfluxunittests/qmltests/tst_qimage.qml
+++ b/tests/quickfluxunittests/qmltests/tst_qimage.qml
@@ -1,7 +1,7 @@
 // To prove that it could pass QImage via AppDispatcher
 import QtQuick 2.0
 import QtTest 1.0
-import QuickFlux 1.0
+import QuickFlux 1.1
 
 TestCase {
     name : "QImageTests"

--- a/tests/quickfluxunittests/quickfluxunittests.pro
+++ b/tests/quickfluxunittests/quickfluxunittests.pro
@@ -1,7 +1,7 @@
-QT += core
+QT += core qmltest
 QT -= gui
 
-CONFIG += c++11
+CONFIG += c++17
 
 TARGET = quickfluxunittests
 CONFIG += console


### PR DESCRIPTION
PR is cherry picked from https://github.com/OneIdentity/quickflux/pull/1 by Imre Steiner.

Compared to the original PR I had to add in `qfstore.cpp`:
```cpp
return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), m_children);
```
to

```cpp
return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), &m_children);
```
and
```cpp
return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), m_redispatchTargets);
```
to

```cpp
return QQmlListProperty<QObject>(qobject_cast<QObject*>(this), &m_redispatchTargets);
```

Co-authored-by: Imre Steiner <imresteiner@users.noreply.github.com>
